### PR TITLE
so capacitor shows the same launch screen as iOS

### DIFF
--- a/ios/Capacitor/Capacitor/Plugins/SplashScreen.swift
+++ b/ios/Capacitor/Capacitor/Plugins/SplashScreen.swift
@@ -3,8 +3,7 @@ import AudioToolbox
 
 @objc(CAPSplashScreenPlugin)
 public class CAPSplashScreenPlugin: CAPPlugin {
-    var imageView = UIImageView()
-    var image: UIImage?
+    var viewController = UIViewController()
     var spinner = UIActivityIndicatorView()
     var showSpinner: Bool = false
     var call: CAPPluginCall?
@@ -27,11 +26,6 @@ public class CAPSplashScreenPlugin: CAPPlugin {
     // Show the splash screen
     @objc public func show(_ call: CAPPluginCall) {
         self.call = call
-
-        if image == nil {
-            call.error("No image named \"Splash\" found. Please check your Assets.xcassets for a file named Splash")
-            return
-        }
 
         let showDuration = call.get("showDuration", Int.self, defaultShowDuration)!
         let fadeInDuration = call.get("fadeInDuration", Int.self, defaultFadeInDuration)!
@@ -63,13 +57,7 @@ public class CAPSplashScreenPlugin: CAPPlugin {
     }
 
     func buildViews() {
-        // Find the image asset named "Splash"
-        // TODO: Find a way to not hard code this?
-        image = UIImage(named: "Splash")
-
-        if image == nil {
-            CAPLog.print("Unable to find splash screen image. Make sure an image called Splash exists in your assets")
-        }
+        viewController = UIStoryboard(name: "LaunchScreen", bundle: nil).instantiateInitialViewController()!
 
         // Observe for changes on frame and bounds to handle rotation resizing
         let parentView = bridge?.viewController?.view
@@ -87,7 +75,7 @@ public class CAPSplashScreenPlugin: CAPPlugin {
     func tearDown() {
         isVisible = false
         bridge?.viewController?.view.isUserInteractionEnabled = true
-        imageView.removeFromSuperview()
+        viewController.view.removeFromSuperview()
 
         if showSpinner {
             spinner.removeFromSuperview()
@@ -106,9 +94,7 @@ public class CAPSplashScreenPlugin: CAPPlugin {
             bridge?.modulePrint(self, "Unable to find root window object for SplashScreen bounds. Please file an issue")
             return
         }
-        imageView.image = image
-        imageView.frame = CGRect(origin: CGPoint(x: 0, y: 0), size: window.bounds.size)
-        imageView.contentMode = .scaleAspectFill
+        viewController.view.frame = CGRect(origin: CGPoint(x: 0, y: 0), size: window.bounds.size)
     }
 
     override public func observeValue(forKeyPath keyPath: String?, of object: Any?, change _: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
@@ -127,7 +113,7 @@ public class CAPSplashScreenPlugin: CAPPlugin {
         }
 
         let view = bridge?.viewController?.view
-        view?.addSubview(imageView)
+        view?.addSubview(viewController.view)
 
         if showSpinner {
             view?.addSubview(spinner)
@@ -155,7 +141,7 @@ public class CAPSplashScreenPlugin: CAPPlugin {
                 return
             }
             if backgroundColor != nil {
-                strongSelf.imageView.backgroundColor = UIColor.capacitor.color(fromHex: backgroundColor!)
+                strongSelf.viewController.view.backgroundColor = UIColor.capacitor.color(fromHex: backgroundColor!)
             }
 
             if strongSelf.showSpinner {
@@ -174,7 +160,7 @@ public class CAPSplashScreenPlugin: CAPPlugin {
             }
 
             if !isLaunchSplash {
-                view.addSubview(strongSelf.imageView)
+                view.addSubview(strongSelf.viewController.view)
 
                 if strongSelf.showSpinner {
                     view.addSubview(strongSelf.spinner)
@@ -185,8 +171,8 @@ public class CAPSplashScreenPlugin: CAPPlugin {
 
             view.isUserInteractionEnabled = false
 
-            UIView.transition(with: strongSelf.imageView, duration: TimeInterval(Double(fadeInDuration) / 1000), options: .curveLinear, animations: {
-                strongSelf.imageView.alpha = 1
+            UIView.transition(with: strongSelf.viewController.view, duration: TimeInterval(Double(fadeInDuration) / 1000), options: .curveLinear, animations: {
+                strongSelf.viewController.view.alpha = 1
 
                 if strongSelf.showSpinner {
                     strongSelf.spinner.alpha = 1
@@ -220,8 +206,8 @@ public class CAPSplashScreenPlugin: CAPPlugin {
         }
         if !isVisible { return }
         DispatchQueue.main.async {
-            UIView.transition(with: self.imageView, duration: TimeInterval(Double(fadeOutDuration) / 1000), options: .curveLinear, animations: {
-                self.imageView.alpha = 0
+            UIView.transition(with: self.viewController.view, duration: TimeInterval(Double(fadeOutDuration) / 1000), options: .curveLinear, animations: {
+                self.viewController.view.alpha = 0
 
                 if self.showSpinner {
                     self.spinner.alpha = 0


### PR DESCRIPTION
Currently, the Splash Screen plugin uses it's own ViewController that only shows
the background image. A developer may have other items like logos or text on
their LaunchScreen, so it should use the LaunchScreen Storyboard instead of
making its own.

https://github.com/ionic-team/capacitor/issues/1871